### PR TITLE
Command route

### DIFF
--- a/python/lib/cloudutils/networkConfig.py
+++ b/python/lib/cloudutils/networkConfig.py
@@ -41,7 +41,7 @@ class networkConfig:
         return devs
     @staticmethod
     def getDefaultNetwork():
-        cmd = bash("route -n|awk \'/^0.0.0.0/ {print $2,$8}\'") 
+        cmd = bash("ip route | awk \'/^default/ {print $3,$5}\'")
         if not cmd.isSuccess():
             logging.debug("Failed to get default route")
             raise CloudRuntimeException("Failed to get default route")


### PR DESCRIPTION
Hi guys,

The command route is not available by default on CentOS7 and recent version of Linux Distrib.
This make cloudstack-setup-agent failed  on fresh install :
route -n|awk '/^0.0.0.0/ {print $2,$8}'

This one should be replace by the command "ip route" as this :
ip route | awk '/^default/ {print $3,$5}'

Another way is to make the net-tools paquet as a dependencies of cloudstack-setup-agent.
